### PR TITLE
Override Jackson dependency

### DIFF
--- a/hdfsMetrics/pom.xml
+++ b/hdfsMetrics/pom.xml
@@ -9,6 +9,7 @@
     <version>1.0</version>
     <properties>
         <hadoop.version>2.5.2</hadoop.version>
+        <jackson.version>1.9.13</jackson.version>
     </properties>
 
 
@@ -34,6 +35,17 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.2</version>
+        </dependency>
+        <!-- ZEN-24517: Override the dependency of jersey-json 1.9 to jackson 1.8.3 -->
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-jaxrs</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-xc</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
     </dependencies>
 

--- a/hdfsMetrics/pom.xml
+++ b/hdfsMetrics/pom.xml
@@ -36,7 +36,7 @@
             <artifactId>httpclient</artifactId>
             <version>4.5.2</version>
         </dependency>
-        <!-- ZEN-24517: Override the dependency of jersey-json 1.9 to jackson 1.8.3 -->
+        <!-- ZEN-24517: Override jackson version in order to use the same version for all jackson components. The version should be whatever hbase depends on. -->
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-jaxrs</artifactId>

--- a/versions.mk
+++ b/versions.mk
@@ -1,6 +1,9 @@
 # Shared definitions for makefiles in download and root subdirectories.
 
-# Versions of third party components used in building the output images
+# Versions of third party components used in building the output images.
+# When either of HBase or Hadoop is upgraded, check the pom file of hdfsMetrics
+# to see if we are using the right versions of other libraries, such as Jackson,
+# using a command like mvn dependency:tree -Dverbose.
 HBASE_VERSION       := 1.1.4
 OPENTSDB_VERSION    := 2.2.0
 HADOOP_VERSION      := 2.5.2


### PR DESCRIPTION
We use v1.9.13 of jackson-core-asl and jackson-mapper-asl. To use the same version, 1.9.13, for all jackson components, add a couple of the dependence tags in the hdfsMetrics pom.